### PR TITLE
test: migrate vue test utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "vuex": "^2.5.0"
   },
   "devDependencies": {
+    "@vue/test-utils": "^1.0.0-beta.13",
     "autoprefixer": "^7.1.6",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",
@@ -86,7 +87,6 @@
     "vue-loader": "^13.5.0",
     "vue-style-loader": "^3.0.3",
     "vue-template-compiler": "^2.5.8",
-    "vue-test-utils": "^1.0.0-beta.6",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.9.1",
     "webpack-dev-middleware": "^1.12.1",

--- a/test/unit/specs/Home.spec.js
+++ b/test/unit/specs/Home.spec.js
@@ -1,4 +1,4 @@
-import { mount } from 'vue-test-utils'
+import { mount } from '@vue/test-utils'
 import Errors from '@/components/ListErrors.vue'
 
 describe('ListErrors.vue', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@vue/test-utils@^1.0.0-beta.13":
+  version "1.0.0-beta.13"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.13.tgz#309dc50d2a55ac9facf781f62bbd236475ba5033"
+  dependencies:
+    lodash "^4.17.4"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1566,7 +1572,7 @@ copy-concurrently@^1.0.0:
     rimraf "^2.5.4"
     run-queue "^1.0.0"
 
-copy-webpack-plugin@^4.2.3:
+copy-webpack-plugin@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz#fc4f68f4add837cc5e13d111b20715793225d29c"
   dependencies:
@@ -6815,12 +6821,6 @@ vue-template-compiler@^2.5.8:
 vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
-
-vue-test-utils@^1.0.0-beta.6:
-  version "1.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/vue-test-utils/-/vue-test-utils-1.0.0-beta.8.tgz#b4f84ce36f7ae457cdbab9ba21771f4a50d4dabd"
-  dependencies:
-    lodash "^4.17.4"
 
 vue@^2.5.8:
   version "2.5.11"


### PR DESCRIPTION
as discussed in #15 we need to migrate vue test utils to the scoped package