### PR TITLE
Redirect image link to user's profile

### DIFF
--- a/src/components/ArticleMeta.vue
+++ b/src/components/ArticleMeta.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="article-meta">
-    <a href=""><img :src="article.author.image"/></a>
+    <router-link
+      :to="{ name: 'profile', params: { 'username': article.author.username } }">
+      <img :src="article.author.image"/>
+    </router-link>
     <div class="info">
       <router-link
         :to="{ name: 'profile', params: { 'username': article.author.username } }"


### PR DESCRIPTION
When a visitor clicks on author's profile pic, he should be redirected to author's profile. This will make the behaviour similar to react-redux example.