### PR TITLE
Make ArticleList exported name  pascal case

### DIFF
--- a/src/components/ArticleList.vue
+++ b/src/components/ArticleList.vue
@@ -7,15 +7,15 @@
       <div v-if="articles.length === 0" class="article-preview">
         No articles are here... yet.
       </div>
-      <rwv-article-preview
+      <RwvArticlePreview
         v-for="(article, index) in articles"
         :article="article"
         :key="article.title + index">
-      </rwv-article-preview>
-      <v-pagination
+      </RwvArticlePreview>
+      <VPagination
         :pages="pages"
         :currentPage.sync="currentPage"
-      ></v-pagination>
+      ></VPagination>
     </div>
   </div>
 </template>

--- a/src/components/ArticleList.vue
+++ b/src/components/ArticleList.vue
@@ -28,7 +28,7 @@ import VPagination from "@/components/VPagination";
 import { FETCH_ARTICLES } from "@/store/actions.type";
 
 export default {
-  name: "rwv-article-list",
+  name: "RwvArticleList",
   components: {
     RwvTag,
     RwvArticlePreview,


### PR DESCRIPTION
For normalized component names, make the default export's name pascal cased in `ArticleList`.

fixes #60 