### PR TITLE
Make API_URL default export

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -1,2 +1,2 @@
-export default {};
 export const API_URL = "https://conduit.productionready.io/api";
+export default API_URL;


### PR DESCRIPTION
From #69
Makes it so that API_URL is a default export as well as a named one.