### PR TITLE
Fix RESET_STATE article mutation

### DIFF
--- a/src/store/article.module.js
+++ b/src/store/article.module.js
@@ -27,7 +27,7 @@ import {
   UPDATE_ARTICLE_IN_LIST
 } from "./mutations.type";
 
-const initialState = {
+const initialState = () => ({
   article: {
     author: {},
     title: "",
@@ -36,9 +36,9 @@ const initialState = {
     tagList: []
   },
   comments: []
-};
+});
 
-export const state = Object.assign({}, initialState);
+export const state = initialState();
 
 export const actions = {
   [FETCH_ARTICLE](context, articleSlug, prevArticle) {
@@ -114,9 +114,11 @@ export const mutations = {
   [TAG_REMOVE](state, tag) {
     state.article.tagList = state.article.tagList.filter(t => t !== tag);
   },
-  [RESET_STATE]() {
+  [RESET_STATE](state) {
+    const newState = initialState();
+
     for (let f in state) {
-      Vue.set(state, f, initialState[f]);
+      Vue.set(state, f, { ...newState[f] });
     }
   }
 };


### PR DESCRIPTION
It was not working as expected since the initialState.article and
initialState.comments was being passed by reference causing side
effects. 

### Solves https://github.com/gothinkster/vue-realworld-example-app/issues/13
The reason the article object was not being reseted was because initialState value was equal the
current state value, since when resetting by the first time, the initialState was passed by reference, so
every time a article field was changed, the same field on the initialState was updated too.