### PR TITLE
Fix typo in mutations.type.js

### DIFF
--- a/src/store/mutations.type.js
+++ b/src/store/mutations.type.js
@@ -9,5 +9,5 @@ export const SET_PROFILE = "setProfile";
 export const SET_TAGS = "setTags";
 export const TAG_ADD = "addTag";
 export const TAG_REMOVE = "removeTag";
-export const UPDATE_ARTICLE_IN_LIST = "updateAricleInList";
+export const UPDATE_ARTICLE_IN_LIST = "updateArticleInList";
 export const RESET_STATE = "resetModuleState";


### PR DESCRIPTION
Typo on line 12:
```
export const UPDATE_ARTICLE_IN_LIST = "updateAricleInList";
```
Should be:
```
export const UPDATE_ARTICLE_IN_LIST = "updateArticleInList";
```