### PR TITLE
rename [FAVORITE_ADD]/[FAVORITE_REMOVE] actions paramater

### DIFF
--- a/src/store/article.module.js
+++ b/src/store/article.module.js
@@ -63,13 +63,13 @@ export const actions = {
     await CommentsService.destroy(payload.slug, payload.commentId);
     context.dispatch(FETCH_COMMENTS, payload.slug);
   },
-  async [FAVORITE_ADD](context, payload) {
-    const { data } = await FavoriteService.add(payload);
+  async [FAVORITE_ADD](context, slug) {
+    const { data } = await FavoriteService.add(slug);
     context.commit(UPDATE_ARTICLE_IN_LIST, data.article, { root: true });
     context.commit(SET_ARTICLE, data.article);
   },
-  async [FAVORITE_REMOVE](context, payload) {
-    const { data } = await FavoriteService.remove(payload);
+  async [FAVORITE_REMOVE](context, slug) {
+    const { data } = await FavoriteService.remove(slug);
     // Update list as well. This allows us to favorite an article in the Home view.
     context.commit(UPDATE_ARTICLE_IN_LIST, data.article, { root: true });
     context.commit(SET_ARTICLE, data.article);


### PR DESCRIPTION
Based on FavoriteService Implementation:
```
export const FavoriteService = {
  add (slug) {
    return APIService.post(`articles/${slug}/favorite`)
  },

  remove (slug) {
    return APIService.delete(`articles/${slug}/favorite`)
  }
}
```
slug is a more intuitive name(while payload is regarded as a map containing multiple parameters,usually used as payload.slug)