### PR TITLE
🔨 Update Prettier to remove some CRLF Warnings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": false,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## TLDR
Add Prettier setting to account for end of line differences between Operating Systems (~80 down to 27).

## Details

On Windows, I'm receiving about 80 of these errors when running `yarn serve`:

![Console error message to delete CR](https://user-images.githubusercontent.com/16465776/66399592-e90bf600-e9ad-11e9-8aee-ca7ae40caa81.png)

Based on what I'm seeing [here](https://stackoverflow.com/questions/1552749/difference-between-cr-lf-lf-and-cr-line-break-types) this is an Operating System difference causing the warnings and telling Prettier to detect the end of line type will adjust this. 