### PR TITLE
Fix tags not routing to tag url

### DIFF
--- a/src/components/VTag.vue
+++ b/src/components/VTag.vue
@@ -16,7 +16,7 @@ export default {
     }
   },
   computed: {
-    homeRoute: () => ({ name: "home-tag", params: { tag: name } })
+    homeRoute: (props) => ({ name: "home-tag", params: { tag: props.name } })
   }
 };
 </script>


### PR DESCRIPTION
Clicking on popular tags doesn't route to tags/:tag. name is coming as undefined in the computed homeRoute