### PR TITLE
fix tag dont response bug

### DIFF
--- a/src/components/VTag.vue
+++ b/src/components/VTag.vue
@@ -16,7 +16,9 @@ export default {
     }
   },
   computed: {
-    homeRoute: () => ({ name: "home-tag", params: { tag: name } })
+    homeRoute() {
+      return { name: "home-tag", params: { tag: this.name } };
+    }
   }
 };
 </script>


### PR DESCRIPTION
Fix a bug.In Homepage when click the tag, there is no response. The problem was cause by Vtag component: Use arrow funtion can't correctly capture this.name variable.