### PR TITLE
Update URL to demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > Vue.js codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld) spec and API.
 
-Project demo is available at https://vue-vuex-realworld.netlify.com/#/
+Project demo is available at https://vue-vuex-realworld.netlify.app/
 
 This codebase was created to demonstrate a fully fledged fullstack application built with **Vue.js** including CRUD operations, authentication, routing, pagination, and more.
 


### PR DESCRIPTION
Can you also update the URL in the repo description?

It took me awhile to realize this redirect was happening and knocking a few points off the Google Lighhouse / Page Speed score (https://github.com/gothinkster/vue-realworld-example-app/issues/109). The overall score is still not very good, but every little bit helps