### PR TITLE
fixed: app still works as logged in, after recieve 401 Unathorized

### DIFF
--- a/src/common/api.service.js
+++ b/src/common/api.service.js
@@ -23,7 +23,8 @@ const ApiService = {
   },
 
   get(resource, slug = "") {
-    return Vue.axios.get(`${resource}/${slug}`).catch(error => {
+    const subpath = slug ? `/${slug}` : ``;
+    return Vue.axios.get(`${resource}` + subpath).catch(error => {
       throw new Error(`[RWV] ApiService ${error}`);
     });
   },

--- a/src/store/auth.module.js
+++ b/src/store/auth.module.js
@@ -8,6 +8,7 @@ import {
   UPDATE_USER
 } from "./actions.type";
 import { SET_AUTH, PURGE_AUTH, SET_ERROR } from "./mutations.type";
+import router from "@/router/index";
 
 const state = {
   errors: null,
@@ -60,8 +61,9 @@ const actions = {
         .then(({ data }) => {
           context.commit(SET_AUTH, data.user);
         })
-        .catch(({ response }) => {
-          context.commit(SET_ERROR, response.data.errors);
+        .catch(() => {
+          context.commit(PURGE_AUTH);
+          router.push({ path: "/" });
         });
     } else {
       context.commit(PURGE_AUTH);


### PR DESCRIPTION
After restart backend (Spring RWApp) DB is purged.
Frontend performs CHECK_AUTH and recieves 401 Unathorized, but still works as logged in with saved in storage token.
Fix: after failed CHECK_AUTH local authentication info purged and user is redirected to home page.
Small fix: removed trailing slash in request URLs.