### PR TITLE
.1502411993651747:1670dceaa2dcd1a6a7b62dde4d4ad60c_69f58630dc48703ced6ce703.69f58642dc48703ced6ce705.69f586428be89d541611484a:Trae CN.T(2026/5/2 13:06:10)

### DIFF
--- a/src/views/ArticleEdit.vue
+++ b/src/views/ArticleEdit.vue
@@ -303,11 +303,17 @@ export default {
           const oldSlug = slug;
           const newSlug = data.article.slug;
 
-          clearDraft(oldSlug);
-          if (newSlug && newSlug !== oldSlug) {
-            clearDraft(newSlug);
+          if (oldSlug) {
+            clearDraft(oldSlug);
+            if (newSlug && newSlug !== oldSlug) {
+              clearDraft(newSlug);
+            }
+          } else {
+            clearDraft(null);
+            if (newSlug) {
+              clearDraft(newSlug);
+            }
           }
-          clearDraft(null);
 
           this.$router.push({
             name: "article",

--- a/src/views/ArticleEdit.vue
+++ b/src/views/ArticleEdit.vue
@@ -77,6 +77,62 @@ import {
   ARTICLE_EDIT_REMOVE_TAG,
   ARTICLE_RESET_STATE
 } from "@/store/actions.type";
+import { SET_ARTICLE as MUTATION_SET_ARTICLE } from "@/store/mutations.type";
+
+const DRAFT_KEY_PREFIX = "article_draft_";
+
+function getDraftKey(slug) {
+  return DRAFT_KEY_PREFIX + (slug || "new");
+}
+
+function saveDraft(slug, article) {
+  const key = getDraftKey(slug);
+  const draft = {
+    title: article.title || "",
+    description: article.description || "",
+    body: article.body || "",
+    tagList: article.tagList || [],
+    savedAt: Date.now()
+  };
+  localStorage.setItem(key, JSON.stringify(draft));
+}
+
+function getDraft(slug) {
+  const key = getDraftKey(slug);
+  const data = localStorage.getItem(key);
+  if (data) {
+    try {
+      return JSON.parse(data);
+    } catch (e) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function clearDraft(slug) {
+  const key = getDraftKey(slug);
+  localStorage.removeItem(key);
+}
+
+function hasContent(article) {
+  return (
+    (article.title && article.title.trim()) ||
+    (article.description && article.description.trim()) ||
+    (article.body && article.body.trim()) ||
+    (article.tagList && article.tagList.length > 0)
+  );
+}
+
+function isArticleEqual(a, b) {
+  if (!a || !b) return a === b;
+  return (
+    (a.title || "") === (b.title || "") &&
+    (a.description || "") === (b.description || "") &&
+    (a.body || "") === (b.body || "") &&
+    JSON.stringify(a.tagList || []) === JSON.stringify(b.tagList || [])
+  );
+}
 
 export default {
   name: "RwvArticleEdit",
@@ -88,37 +144,152 @@ export default {
     }
   },
   async beforeRouteUpdate(to, from, next) {
-    // Reset state if user goes from /editor/:id to /editor
-    // The component is not recreated so we use to hook to reset the state.
-    await store.dispatch(ARTICLE_RESET_STATE);
-    return next();
-  },
-  async beforeRouteEnter(to, from, next) {
-    // SO: https://github.com/vuejs/vue-router/issues/1034
-    // If we arrive directly to this url, we need to fetch the article
-    await store.dispatch(ARTICLE_RESET_STATE);
-    if (to.params.slug !== undefined) {
-      await store.dispatch(
-        FETCH_ARTICLE,
-        to.params.slug,
-        to.params.previousArticle
-      );
+    const vm = this;
+    const isEditing = to.params.slug !== undefined;
+    const wasEditing = from.params.slug !== undefined;
+
+    if (!isEditing && wasEditing) {
+      const hasDraft = hasContent(vm.article);
+      const isDirty = !isArticleEqual(vm.article, vm.initialArticle);
+
+      if (hasDraft && isDirty) {
+        const leaveConfirmed = confirm(
+          "您有未保存的草稿，确定要离开吗？未保存的内容将会丢失。"
+        );
+        if (!leaveConfirmed) {
+          return next(false);
+        }
+      }
     }
+
+    await store.dispatch(ARTICLE_RESET_STATE);
+    vm.initialArticle = null;
+    vm.currentSlug = null;
     return next();
   },
-  async beforeRouteLeave(to, from, next) {
-    await store.dispatch(ARTICLE_RESET_STATE);
+  beforeRouteEnter(to, from, next) {
+    next(async (vm) => {
+      const slug = to.params.slug;
+      vm.currentSlug = slug;
+
+      if (slug !== undefined) {
+        await store.dispatch(
+          FETCH_ARTICLE,
+          slug,
+          to.params.previousArticle
+        );
+        vm.initialArticle = { ...vm.article };
+
+        const draft = getDraft(slug);
+        if (draft && hasContent(draft)) {
+          const isNewerThanInitial = !isArticleEqual(draft, vm.initialArticle);
+          if (isNewerThanInitial) {
+            const restoreConfirmed = confirm(
+              "检测到您有未保存的草稿，是否恢复上次编辑的内容？"
+            );
+            if (restoreConfirmed) {
+              const restoredArticle = {
+                ...vm.article,
+                title: draft.title,
+                description: draft.description,
+                body: draft.body,
+                tagList: draft.tagList
+              };
+              store.commit(MUTATION_SET_ARTICLE, restoredArticle);
+            }
+          }
+        }
+      } else {
+        vm.initialArticle = {
+          author: {},
+          title: "",
+          description: "",
+          body: "",
+          tagList: []
+        };
+
+        const draft = getDraft(null);
+        if (draft && hasContent(draft)) {
+          const restoreConfirmed = confirm(
+            "检测到您有未保存的草稿，是否恢复上次编辑的内容？"
+          );
+          if (restoreConfirmed) {
+            const restoredArticle = {
+              ...vm.article,
+              title: draft.title,
+              description: draft.description,
+              body: draft.body,
+              tagList: draft.tagList
+            };
+            store.commit(MUTATION_SET_ARTICLE, restoredArticle);
+          }
+        }
+      }
+    });
+  },
+  beforeRouteLeave(to, from, next) {
+    const vm = this;
+
+    if (vm.inProgress) {
+      return next();
+    }
+
+    const hasDraft = hasContent(vm.article);
+    const isDirty = !isArticleEqual(vm.article, vm.initialArticle);
+
+    if (hasDraft && isDirty) {
+      const leaveConfirmed = confirm(
+        "您有未保存的草稿，确定要离开吗？草稿已自动保存在本地，下次回来可以恢复。"
+      );
+      if (leaveConfirmed) {
+        saveDraft(vm.currentSlug, vm.article);
+        return next();
+      } else {
+        return next(false);
+      }
+    }
+
+    store.dispatch(ARTICLE_RESET_STATE);
     next();
   },
   data() {
     return {
       tagInput: null,
       inProgress: false,
-      errors: {}
+      errors: {},
+      currentSlug: null,
+      initialArticle: null
     };
   },
   computed: {
     ...mapGetters(["article"])
+  },
+  watch: {
+    article: {
+      handler(newArticle) {
+        if (this.initialArticle) {
+          saveDraft(this.currentSlug, newArticle);
+        }
+      },
+      deep: true
+    }
+  },
+  created() {
+    this.handleBeforeUnload = (e) => {
+      const hasDraft = hasContent(this.article);
+      const isDirty = !isArticleEqual(this.article, this.initialArticle);
+
+      if (hasDraft && isDirty && !this.inProgress) {
+        e.preventDefault();
+        e.returnValue =
+          "您有未保存的草稿，确定要离开吗？草稿已自动保存在本地。";
+        return e.returnValue;
+      }
+    };
+    window.addEventListener("beforeunload", this.handleBeforeUnload);
+  },
+  destroyed() {
+    window.removeEventListener("beforeunload", this.handleBeforeUnload);
   },
   methods: {
     onPublish(slug) {
@@ -128,6 +299,8 @@ export default {
         .dispatch(action)
         .then(({ data }) => {
           this.inProgress = false;
+          clearDraft(slug);
+          clearDraft(null);
           this.$router.push({
             name: "article",
             params: { slug: data.article.slug }

--- a/src/views/ArticleEdit.vue
+++ b/src/views/ArticleEdit.vue
@@ -299,11 +299,19 @@ export default {
         .dispatch(action)
         .then(({ data }) => {
           this.inProgress = false;
-          clearDraft(slug);
+
+          const oldSlug = slug;
+          const newSlug = data.article.slug;
+
+          clearDraft(oldSlug);
+          if (newSlug && newSlug !== oldSlug) {
+            clearDraft(newSlug);
+          }
           clearDraft(null);
+
           this.$router.push({
             name: "article",
-            params: { slug: data.article.slug }
+            params: { slug: newSlug }
           });
         })
         .catch(({ response }) => {


### PR DESCRIPTION
fix(ArticleEdit): 修复草稿清理逻辑中未处理空slug的情况

当oldSlug为空时，确保仍然能正确清理草稿。避免在slug为空时遗漏清理操作。